### PR TITLE
fix: deletingUI for  books patrons that do not exists

### DIFF
--- a/LosGosus/src/ConsoleInterface/ManagersUI/BookManagerUI.cs
+++ b/LosGosus/src/ConsoleInterface/ManagersUI/BookManagerUI.cs
@@ -110,8 +110,13 @@ public class BookManagerUI
         string isbn = AnsiConsole.Ask<string>("Enter ISBN of the book to delete:");
         try
         {
-            bookController.DeleteBook(isbn);
-            AnsiConsole.MarkupLine("[green]Book deleted successfully![/]");
+            if(bookController.DeleteBook(isbn))
+            {
+                AnsiConsole.MarkupLine("[green]Book deleted successfully![/]");
+            }else
+            {
+                AnsiConsole.MarkupLine("[red]Error deleting the book[/]");
+            }
         }
         catch (Exception)
         {

--- a/LosGosus/src/ConsoleInterface/ManagersUI/PatronManagerUI.cs
+++ b/LosGosus/src/ConsoleInterface/ManagersUI/PatronManagerUI.cs
@@ -102,8 +102,14 @@ public class PatronManagerUI
         string membershipNumber = AnsiConsole.Ask<string>("Enter Patron Membership Number:");
         try
         {
-            patronController.DeletePatron(membershipNumber);
-            AnsiConsole.MarkupLine("[green]Patron deleted successfully![/]");
+            if (patronController.DeletePatron(membershipNumber))
+            {
+                AnsiConsole.MarkupLine("[green]Patron deleted successfully![/]");
+            } else
+            {
+                AnsiConsole.MarkupLine("[red]Error deleting the patron![/]");
+
+            }
         }
         catch (Exception)
         {
@@ -116,7 +122,7 @@ public class PatronManagerUI
     {
         AnsiConsole.MarkupLine("[bold yellow]Listing all patrons:[/]");
         patronController.ListPatrons();
-        
+   
     }
 
     private void SearchPatrons()


### PR DESCRIPTION
bugfix on UI for Book and Patron deleting now gives a message that the deletion was not succesfull for books and patrons that doesnt exists