### PR TITLE
fix: generate report for only existent patrons

### DIFF
--- a/LosGosus/src/ConsoleInterface/ServicesUI/BorrowingUI.cs
+++ b/LosGosus/src/ConsoleInterface/ServicesUI/BorrowingUI.cs
@@ -151,8 +151,14 @@ public class BorrowingUI
 
             if (!string.IsNullOrEmpty(membershipNumber))
             {
-                var borrowingHistoryReport = _borrowingManager.GetBorrowingHistory(membershipNumber);
-                File.WriteAllText(Path.Combine(reportsDirectory, $"{membershipNumber}_BorrowingHistory.txt"), borrowingHistoryReport);
+                string borrowingHistoryReport = _borrowingManager.GetBorrowingHistory(membershipNumber);
+                if(!string.IsNullOrEmpty(borrowingHistoryReport))
+                {
+                    File.WriteAllText(Path.Combine(reportsDirectory, $"{membershipNumber}_BorrowingHistory.txt"), borrowingHistoryReport);
+                } else 
+                {
+                    AnsiConsole.MarkupLine("[red]Error generating borrowing history: {0}[/]");
+                }
             }
             else
             {


### PR DESCRIPTION
The generation of reports generates a report for valid or invalid patrons even patrons that doesnt exist, so in this fix only generates reports for existent patrons that has borrows. 
Why?
For not having empty txt archieves for not existent patterns.